### PR TITLE
Bdfl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agmljs
 
-ansuz' ghetto markup language
+ansuz' ghetto markup language, or, if that offends you: `ansuz' ghetto markup language`.
 
 ## Why?
 
@@ -8,42 +8,190 @@ I wanted a really, really tiny language for a configuration file, so I made one.
 
 `agml` is based on some work by [kpcyrd](https://github.com/kpcyrd). The comment syntax was designed in part by [prurigro](https://github.com/prurigro).
 
+It started off as a bit of a joke, but as it turns out, the language has some nice properties.
+
+1. It's extremely easy to read.
+2. It parses each line as either a valid attribute or a comment, and never complains, which puts it well in line with the philosophy of [literate programming](http://en.wikipedia.org/wiki/Literate_programming).
+3. Depending on the implementation (afaik this is currently the only one) you can call it with options that make it able to parse other configuration language like [ini](http://en.wikipedia.org/wiki/INI_file).
+4. You don't need to parse a full file to append new values to it, as you would with json or xml, a property which lends itself well to many applications.
+
+## Why not?
+
+AGML was designed to be tiny, and simple. As such, it will not be suitable for all tasks.
+
+If your project requires a configuration format that permits nested data structures, move on now.
+
+## Is AGML stable?
+
+I wrote this really quickly, and started taking it more seriously after the fact. A few people have asked when to expect an RFC, (an entertaining thought). I plan to push a few selfish designs, then open up to more input.
+
+Once that RFC comes in, things should stay pretty stable.
+
+## The current specification
+
+AGML comes in two forms:
+
+### 1 :: Quick and Dirty AGML
+
+```
+just start writing
+
+you don't need to do anything more
+
+this is a key : this is a value
+
+This is another key : this is another value
+
+this is a key : this value overwrites previous values with identical keys
+```
+
+What does that return?
+
+```
+[
+  {
+    "this is a key":"this value overwrites previous values with identical keys",
+    "This is another key":"this is another value"
+  }
+]
+```
+
+### 2 :: Delimited AGML
+
+```
+---
+
+this is useful if you want to pass a large body of text
+
+and have the parser only bother with a small piece of it
+
+start and end a block with three consecutive dashes, it'll ignore everything else.
+
+I use this for annotating my markdown with metadata.
+
+for bonus points, you can space out your lines like this, and it'll parse as valid Markdown
+
+Those triple dashes render as an hr element
+
+title: AGML
+
+author: ansuz
+
+description: ansuz' ghetto markup language
+
+---
+
+And then I put blog content below.
+
+`key:value` <- this won't be parsed as AGML, since it isn't within the block.
+```
+
+That will return:
+
+```
+[
+  {
+    title:"AGML",
+    author:"ansuz",
+    description:"ansuz' ghetto markup language"
+  }
+]
+```
+
+### 2b :: Multiply delimited AGML
+
+```
+---
+
+for situations when you want a collection of data
+
+put multiple blocks, and they will be collected into the returned array
+
+I use this for an AGML to RSS utility
+
+the first block specifies my channel data
+
+title: transitiontech.ca
+
+link : http://transitiontech.ca
+
+description : ansuz' blag
+
+category : technology
+
+generator : AGML2RSS
+
+---
+
+Then you can drop in the actual RSS items
+
+---
+title : one
+link  : http://transitiontech.ca/one
+description : my first blag post
+---
+
+---
+title : two
+link  : http://transitiontech.ca/two
+description : my second blag post
+---
+
+---
+title : three
+link  : http://transitiontech.ca/three
+description : my third blag post
+---
+```
+
+This will return
+
+```
+[
+  {
+    title:"transitiontech.ca",
+    link:"http://transitiontech.ca",
+    description:"ansuz' blag",
+    category:"technology",
+    generator:"AGML2RSS"
+  },
+  {
+    title:"one",
+    link:"http:/transitiontech.ca/one",
+    description:"my first blag post"
+  },
+  {
+    title:"two",
+    link:"http:/transitiontech.ca/two",
+    description:"my second blag post"
+  },
+  {
+    title:"three",
+    link:"http:/transitiontech.ca/three",
+    description:"my third blag post"
+  }
+]
+```
+
+To work with this data, I just make two assignments:
+
+```
+var channelData=myAGML[0];
+var itemData=myAGML.slice(1);
+```
+
+With an AGML to XML converter (which is pretty easy), you can just append new posts to a `.agml` file, no parsing required.
+
+It would also be trivial to implement some logic to only use the last `n` posts, if the number of posts is greater than `n`, but that's beyond the scope of this writeup.
+
 ## How?
 
 ```Javascript
 var agml=require("./agml");
 
-var yourResults=agml.parse(yourText);
+var results={};
 
-console.log(yourResults);
-```
+agml.parse(yourText,results);
 
-## What?!?
-
-```Javascript
-var aMultiLineString=function(){/*
-
-a key : a value
-
-another key : another value ; this is a comment, since it's after a semicolon
-
-
-: a comment
-
-; another comment
-
-this is a comment too, since there's no colon
-
-*/}.toString().slice(14,-3);
-```
-
-## Huh?
-
-That will yield the following:
-
-```agml
-{
-  "a key": "a value",
-  "another key": "another value"
-}
+console.log(results);
 ```

--- a/agml.js
+++ b/agml.js
@@ -1,4 +1,6 @@
-var agml={};
+var agml={
+  results:[]  
+};
 
 /*
   agml parse takes three arguments
@@ -16,39 +18,75 @@ agml.parse=function(text,results,opt){
   // objects are passed by reference in javascript
   // so you can pass an object like a pointer in C
   // and agml.parse will load the results into that
-  results=results||{};
+
+  results=results||agml.results; 
   opt=opt||{};
-  opt.delim=opt.delim||':';
-  opt.trail=opt.trail||';';
+  var delim=opt.delim||':';
+  var trail=opt.trail||';';
+  var block=opt.block||'-';
+  var replace=opt.replace||true;
 
-  var leadingComment=new RegExp('^\\s*'+opt.delim);
-  var keyPattern=new RegExp('.*?'+opt.delim);
-  var trailingComment=new RegExp(opt.trail+'.*$');
+  var leadingComment=new RegExp('^\\s*'+delim);
+  var keyPattern=new RegExp('.*?'+delim);
+  var trailingComment=new RegExp(trail+'.*$');
+  var agmlBlock= new RegExp('\\'+block+'{3}(.|\s|\n)+?\\'+block+'{3}','mg');
 
-  // split into individual lines
-  // agml can't split key-value pairs across lines
-  text.split('\n')
-    // throw away empty lines, or lines with whitespace as keys
-    .filter(function(line){
-      return (!line || leadingComment.test(line))?false:true;
-    })
-    // parse each line
-    .forEach(function(line){
-      // a line is only relevant if it contains a colon
-      if(/:/.test(line)){
-        var key,val;
-        // extract the key, assign the remainder to the value
-        val=line.replace(keyPattern,function(k){
-          // but don't keep the colon
-          key=k.slice(0,-1);
-          return '';
-          // also, throw away anything after a semicolon
-        }).replace(trailingComment,'');
-        // add your results to a dictionary
-        results[key.trim()]=val.trim();
+  var toJSON=function(AGML){
+    var temp={};
+
+    // split into individual lines
+    // agml can't split key-value pairs across lines
+    AGML.split('\n')
+      // throw away empty lines, or lines with whitespace as keys
+      .filter(function(line){
+        return (!line || leadingComment.test(line))?false:true;
+      })
+      // parse each line
+      .forEach(function(line){
+        // a line is only relevant if it contains a colon
+        if(/:/.test(line)){
+          var key,val;
+          // extract the key, assign the remainder to the value
+          val=line.replace(keyPattern,function(k){
+            // but don't keep the colon
+            key=k.slice(0,-1);
+            return '';
+            // also, throw away anything after a semicolon
+          }).replace(trailingComment,'');
+          // add your results to a dictionary
+          temp[key.trim()]=val.trim();
+        }
+      });
+    results.push(temp);
+  };
+
+  // if you detect at least one delimited block of AGML
+  // just parse that, and (optionally) remove it from the text
+  if(agmlBlock.test(text)){
+    (function(){
+      // a temporary array
+      var temp=[];
+
+      // parse out the content of the blocks
+      var tempText=text.replace(agmlBlock,function(block){
+        temp.push(block.slice(3,-3));  
+      });
+
+      // call 'toJSON' on each block
+      // this pushes to your results array
+      temp.forEach(toJSON);
+
+      // unless explicitly instructed not to
+      // erase the parsed blocks from the source text
+      if(replace){
+        text=tempText;
       }
-    });
-  return results;
+    }());
+  }else{
+    // just extract the values
+    // don't do anything to the source text
+    toJSON(text);
+  }
 };
 
 /*
@@ -61,32 +99,11 @@ agml.parse=function(text,results,opt){
 
 agml.encode=function(dict,opt){
   opt=opt||{};
-  opt.delim=opt.delim||':';
+  opt.delim=opt.delim||':'; 
   return Object.keys(dict)
     .map(function(key){
       return key+opt.delim+dict[key];
     }).join('\n');
-};
-
-/*
-  agml.head takes a string, a results object, and an options object
-    and returns an array
-*/
-
-agml.head=function(text,results,opt){
-  /*
-      parse a section of text
-      filter out bits contained in '---' blocks
-      extract the data, return the text
-  */
-  opt.delim=opt.delim||'-';
-
-  var results=[];
-  return text.replace(new RegExp('\\'+opt.delim+'{3}(.|\s)*?\\'+opt.delim+'{3}','mg'),function(head){
-    results.push(head.slice(3,-3));
-    return '';
-  });
-  return results;
 };
 
 module.exports=agml;

--- a/agml.js
+++ b/agml.js
@@ -112,7 +112,7 @@ agml.parse=function(text,results,opt){
 agml.encode=function(dict,opt){
   opt=opt||{};
   var delim=opt.delim||agml.delim;
-  var separator=opt.separator||agml.separator; \\ \n
+  var separator=opt.separator||agml.separator; // \n
 
   return Object.keys(dict)
     .map(function(key){

--- a/agml.js
+++ b/agml.js
@@ -149,4 +149,5 @@ agml.encode=function(blocks,opt){
   });
 };
 
-module.exports=agml;
+if(typeof module !== 'undefined')
+  module.exports=agml;

--- a/agml.js
+++ b/agml.js
@@ -1,5 +1,11 @@
 var agml={
-  results:[]  
+  results:[],
+  block:'-',
+  trail:';',
+  delim:':',
+  replace:true,
+  firstOnly:false,
+  separator:'\n'
 };
 
 /*
@@ -21,22 +27,28 @@ agml.parse=function(text,results,opt){
 
   results=results||agml.results; 
   opt=opt||{};
-  var delim=opt.delim||':';
-  var trail=opt.trail||';';
-  var block=opt.block||'-';
-  var replace=opt.replace||true;
+  var delim=opt.delim||agml.delim;
+  var trail=opt.trail||agml.trail;
+  var block=opt.block||agml.block;
+  var replace=opt.replace||agml.replace;
+  var separator=opt.separator||agml.separator;
+
+  // if opt.firstOnly has any truthy value
+  // the agmlBlock regex will only grab the first block
+  // otherwise it will grab all blocks
+  var blockFlags=opt.firstOnly?'m':'mg';
 
   var leadingComment=new RegExp('^\\s*'+delim);
   var keyPattern=new RegExp('.*?'+delim);
   var trailingComment=new RegExp(trail+'.*$');
-  var agmlBlock= new RegExp('\\'+block+'{3}(.|\s|\n)+?\\'+block+'{3}','mg');
+  var agmlBlock= new RegExp('\\'+block+'{3}(.|\s|\n)+?\\'+block+'{3}',blockFlags);
 
   var toJSON=function(AGML){
     var temp={};
 
     // split into individual lines
     // agml can't split key-value pairs across lines
-    AGML.split('\n')
+    AGML.split(separator) // defaults to '\n' (newline)
       // throw away empty lines, or lines with whitespace as keys
       .filter(function(line){
         return (!line || leadingComment.test(line))?false:true;
@@ -99,11 +111,13 @@ agml.parse=function(text,results,opt){
 
 agml.encode=function(dict,opt){
   opt=opt||{};
-  opt.delim=opt.delim||':'; 
+  var delim=opt.delim||agml.delim;
+  var separator=opt.separator||agml.separator; \\ \n
+
   return Object.keys(dict)
     .map(function(key){
       return key+opt.delim+dict[key];
-    }).join('\n');
+    }).join(separator);
 };
 
 module.exports=agml;

--- a/agml2rss.js
+++ b/agml2rss.js
@@ -1,0 +1,66 @@
+var fs=require("fs");
+var agml=require("./agml");
+
+var args=process.argv.slice(2);
+
+if(args.length<1){
+  console.log("Try passing the name of an agml file");
+  process.exit();
+}
+
+var source=args.map(function(fn){
+  return fs.readFileSync(fn,'utf-8');
+});
+
+var rss={};
+
+var swap=function(text,dict){
+  return text.replace(/\{.*?\}/g,function(key){
+    var temp=key.slice(1,-1);
+    return dict[temp]||'ERR';
+  });
+};
+
+rss.makeTag=function(type,content){
+  return swap('<{type}>\n\t{content}\n</{type}>',{
+    type:type,
+    content:Object.keys(content)
+    .map(function(key){
+      return swap('<{key}>{val}</{key}>',{
+        key:key,
+        val:content[key]
+      });
+    }).join("\n\t")
+  });
+};
+
+rss.makeFeed=function(source){
+  var results=[];
+  agml.parse(source,results);
+  var channel=results[0];
+  var items=results.slice(1);
+//  console.log(JSON.stringify(results,undefined,2));
+  var channelXML=rss.makeTag('channel',channel);
+  var itemsXML=items.map(function(item){
+
+    return rss.makeTag('item',item);
+  }).join("\n");
+
+  var frame=function(){/*<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+{channel}
+{items}
+</rss>
+*/}.toString().slice(14,-3);
+
+  var final=swap(frame,{
+    channel:channelXML,
+    items:itemsXML
+  });
+
+  return final;
+};
+
+source.map(function(source){
+  console.log(rss.makeFeed(source));
+});

--- a/test.js
+++ b/test.js
@@ -18,11 +18,8 @@ this is a comment
 
 ;   pew pew pew
 
-
-
 */}.toString().slice(14,-3);
 
+agml.parse(text);
 
-var results=agml.parse(text);
-
-console.log(results);
+console.log(JSON.stringify(agml.results,undefined,2));

--- a/test2.js
+++ b/test2.js
@@ -1,0 +1,26 @@
+var agml=require("./agml");
+
+var text=function(){/*
+---
+a : bang!
+b : pewpew
+---
+
+---
+a:  bloppp
+b: !zing™
+
+
+this is valid : this is valid too ; this is a comment
+
+---
+
+some extra stuff
+
+this resembles a key : but it is not
+
+*/}.toString().slice(14,-3);
+
+agml.parse(text);
+
+console.log(JSON.stringify(agml.results,undefined,2));

--- a/test3.js
+++ b/test3.js
@@ -1,0 +1,14 @@
+var agml=require("./agml");
+
+var text=function(){/*
+a : bang!
+b : pewpew
+b : non destructive mode makes everything an array
+
+*/}.toString().slice(14,-3);
+
+agml.parse(text,undefined,{
+  destructive:false // disable destructive mode
+});
+
+console.log(JSON.stringify(agml.results,undefined,2));

--- a/tips.md
+++ b/tips.md
@@ -1,0 +1,60 @@
+---
+
+title: tips
+
+author: ansuz
+
+description : some cool stuff you can do with agml
+
+---
+
+### Multiline values
+
+By default, the AGML parser looks at individual lines to find key-value pairs. This causes problems if you want to include multiline values.
+
+To override this behaviour, pass a different `separator` option. It comes in the form of a string, so if you want to delimit _lines_ of agml by double-newlines, instead of the default single, pass the following option:
+
+```JSON
+{
+  separator:"\n\n"
+}
+```
+
+A multiline value
+
+```AGML
+---
+
+someKey: now you can have
+a multiline value
+in your agml
+pretty cool, right?
+
+---
+```
+
+
+###  Markdown blocks as values
+
+Markdown treats double-newlines as significant, so if you want to be able to pass sections of markdown as values, you'll need to change your `separator` value to ignore double-newlines:
+
+```JSON
+{
+  separator:"\n\n\n"
+}
+```
+
+Markdown in your AGML
+
+```AGML
+---
+
+navigation:
+* [a link](http://example.tld)
+* [another link](http://gfy.com)
+
+
+that's all, folks!
+
+---
+```


### PR DESCRIPTION
1. agml return type is `ALWAYS AN ARRAY`
2. the array consists of at least one object
3. You can provide a bunch of options which change the behaviour of the parser to account for different delimiters and stuff like that.
4. if you fail to pass a reference to an array, the new blocks of agml will be pushed to `agml.results`
5. there are examples of alternate options you can pass for different behaviours.
